### PR TITLE
init.universal3470.rc: fix gpsd battery drain issue.

### DIFF
--- a/rootdir/etc/init.universal3470.rc
+++ b/rootdir/etc/init.universal3470.rc
@@ -549,7 +549,7 @@ service mobicore /system/bin/mcDriverDaemon -r /system/app/FFFFFFFF0000000000000
 service gpsd /system/bin/gpsd -c /system/etc/gps.xml
     class main
     user gps
-   group system wakelock inet net_raw
+    group system inet net_raw
     ioprio be 0
 #    seclabel u:r:gpsd:s0
 


### PR DESCRIPTION
Because we're using the same GPS blobs, this small change should also fix the gpsd wakelock issue for the kminilte,
my bugreport's showed me, that this wakelock was always there.
